### PR TITLE
Improved query. Uses pathlib, configparser, tempfile.

### DIFF
--- a/firefox-recent.py
+++ b/firefox-recent.py
@@ -1,36 +1,71 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
-import sqlite3
-import os
-import shutil
 import re
+import shutil
+import sqlite3
+import tempfile
+import configparser
+from pathlib import Path
+
+
+FIREFOX_HOME = Path.home() / ".mozilla/firefox"
+
+
+def sqlite_regexp(pattern, string):
+    return re.search(pattern, string) != None
+
 
 def copy_db(location):
-    destination = os.path.expanduser("~") + "/.firefox_places_copy.sqlite"
-    if os.path.exists(destination):
-        os.remove(destination)
-    shutil.copy2(location, destination)
-    return(destination)
+    destination = Path(tempfile.mkstemp()[1])
+    shutil.copy2(str(location), str(destination))
+
+    return destination
+
 
 def get_profile_name():
-    profiles_path = os.path.expanduser('~')+"/.mozilla/firefox/profiles.ini"
-    with open(profiles_path) as p:
-        lines = p.readlines()
-        profile_matches = [re.search(r"^Path=(.*\.default)$", l).group(1)
-                           for l in lines if l.startswith( 'Path' )]
-        profile = profile_matches.pop()
-        return(profile)
-        
+    config = configparser.ConfigParser()
+    config.read(FIREFOX_HOME / "profiles.ini")
+    # 99% of the time this will be your profile
+    profile = config["Profile0"]["Path"]
+
+    # but just in case:
+    profiles = [
+        section for section in list(config.keys()) if section.startswith("Profile")
+    ]
+    if profiles and len(profile) > 1:
+        for name in profiles:
+            if config[name]["Default"] == 1:
+                profile = config[name]["Path"]
+                break
+
+    return profile
+
+
+def select_recent(db_file):
+    conn = sqlite3.connect(db_file)
+    conn.create_function("REGEXP", 2, sqlite_regexp)
+    cursor = conn.cursor()
+    select_statement = (
+        "SELECT DISTINCT RTRIM(url,'/') "
+        "FROM moz_places "
+        "WHERE url REGEXP '^(.*):\/\/' "
+        "ORDER BY moz_places.visit_count DESC"
+    )
+    cursor.execute(select_statement)
+    result = cursor.fetchall()
+    cursor.close()
+
+    return result
+
+
 def main():
     profile_name = get_profile_name()
-    places_path = os.path.expanduser('~')+"/.mozilla/firefox/{}/places.sqlite".format(profile_name)
-    db = copy_db(places_path)
-    c = sqlite3.connect(db)
-    cursor = c.cursor()
-    select_statement = "select moz_places.url, moz_places.visit_count from moz_places order by moz_places.visit_count desc;"
-    cursor.execute(select_statement)
-    results = cursor.fetchall()
-    print("\n".join([r[0] for r in results]))
+    db_file = copy_db(FIREFOX_HOME / f"{profile_name}/places.sqlite")
+    results = select_recent(db_file)
+
+    print("\n".join([row[0] for row in results]))
+    db_file.unlink()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
* Uses `configparser` instead of a nasty regex. 
* `tempfile` for the copied db
* `pathlib` to read firefox files

Also the sqlite3 query selects (distinct) stored urls that start with `something://` and removes trailing /